### PR TITLE
Allow self references but exclude them from sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You may have a schema in the target database which is stricter than the source d
 
 - Only supports foreign keys that reference the `id` field of the parent table.
 - If the schemas of the tables differ at all you'll get errors - you can use the post_copy_sql parameter to add SQL that fixes this, but it's still a manual process.
-- Self relations aren't properly supported - so you need to make sure there aren't any self-relations using conditions
+- Self relations aren't properly supported, they are excluding from sampling. If you don't want such tables to be copied without sampling, add them to the exclude list.
 
 ## Recommendations
 


### PR DESCRIPTION
As far as I understood, the only problem with self-references is that it is hard or even sometimes impossible to sample correctly.

Assuming I did not miss anything, I suggest allowing self-references in the copy but excluding them from sampling. If the table size is acceptable, it's much less work for the user to make the complete export. If the table is too big, it can simply be excluded from the copy and sampled manually, which was already the case anyway.